### PR TITLE
Don't consult collection_timestamp to get the collection timestamp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 0.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update to match kinto 10.1.1 -- see Kinto/kinto#1770 (#2).
 
 
 0.1.0 (2018-09-12)

--- a/kinto_megaphone/listeners.py
+++ b/kinto_megaphone/listeners.py
@@ -18,9 +18,6 @@ class CollectionTimestampListener(ListenerBase):
 
         bucket_id = event.payload['bucket_id']
         collection_id = event.payload['collection_id']
-        parent_id = utils.instance_uri(event.request, 'collection',
-                                       bucket_id=bucket_id,
-                                       id=collection_id)
         timestamp = event.payload['timestamp']
         etag = '"{}"'.format(timestamp)
         self.client.send_version(self.broadcaster_id,

--- a/kinto_megaphone/listeners.py
+++ b/kinto_megaphone/listeners.py
@@ -21,8 +21,7 @@ class CollectionTimestampListener(ListenerBase):
         parent_id = utils.instance_uri(event.request, 'collection',
                                        bucket_id=bucket_id,
                                        id=collection_id)
-        storage = event.request.registry.storage
-        timestamp = storage.collection_timestamp('record', parent_id)
+        timestamp = event.payload['timestamp']
         etag = '"{}"'.format(timestamp)
         self.client.send_version(self.broadcaster_id,
                                  '{}_{}'.format(bucket_id, collection_id),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-kinto==10.0.0
+kinto==10.1.1
 requests==2.19.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with codecs.open(os.path.join(here, 'CONTRIBUTORS.rst'),
 
 
 REQUIREMENTS = [
-    'kinto',
+    'kinto >= 10.1.1',
     'requests',
 ]
 

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -96,11 +96,10 @@ def test_kinto_listener_puts_version():
         {'new': {'id': 'abcd'}}
     ]
     request = DummyRequest()
-    request.registry.storage.collection_timestamp.return_value = 125
     event = events.ResourceChanged(payload, single_record, request)
 
     listener(event)
-    client.send_version.assert_called_with('broadcaster', 'food_french', '"125"')
+    client.send_version.assert_called_with('broadcaster', 'food_french', '"123"')
 
 
 def test_kinto_listener_ignores_writes_not_on_records():


### PR DESCRIPTION
Rely on the event payload instead. This is the right move e.g. for events
generated by kinto-changes that don't correspond to a "real"
collection and therefore don't have a "real" collection_timestamp.

Depends on Kinto/kinto#1769.